### PR TITLE
Add verification parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,13 @@ from pydantic import BaseModel
 
 from fastapi_resource_server import JwtDecodeOptions, OidcResourceServer
 
-app = FastAPI()
+decode_options = JwtDecodeOptions(require_aud=True, require_issuer=True)
+decode_kwargs = JwtKwargs(audience="my-client", issuer="http://localhost:8888/auth/realms/master")
 
-decode_options = JwtDecodeOptions(verify_aud=False)
+app = FastAPI(swagger_ui_init_oauth={"clientId": decode_kwargs.audience})
 
 auth_scheme = OidcResourceServer(
-    "http://localhost:8888/auth/realms/master",
+    decode_kwargs.issuer,
     scheme_name="Keycloak",
     jwt_decode_options=decode_options,
 )


### PR DESCRIPTION
* Allow passing values to validate against the token
* Update example to verify audience and issuer, and pass client ID to swagger documentation to make it easier to play around with the backend